### PR TITLE
ci: raise Go toolchain to 1.23

### DIFF
--- a/.github/workflows/on-push-pr.yml
+++ b/.github/workflows/on-push-pr.yml
@@ -9,7 +9,7 @@ jobs:
   format-build-test:
     strategy:
       matrix:
-        go-version: ['1.19.x', '1.21.x']
+        go-version: ['1.23.x', '1.24.x']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
 
       - run: CGO_ENABLED=0 make release
 
@@ -109,7 +109,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
 
       - name: verify mysql
         run: |

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
 
       - run: CGO_ENABLED=0 make release
 

--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
 WORKDIR /go/app
 


### PR DESCRIPTION
The macos-latest runner label now points at macOS 26, whose loader strictly requires LC_UUID in Mach-O binaries. Go 1.22 and earlier emit binaries without it, so `go test` abort traps on that platform.

Move the test matrix to 1.23.x/1.24.x. The release and mysql-test jobs and the Dockerfile.buildx builder image, all still pinned at the EOL 1.21, move to 1.23 for consistency; those build on Linux and are unaffected by LC_UUID.

This raises only the toolchain CI and image builds use. go.mod stays at 1.19 — no new language features are used, and what downstream consumers can compile with is unchanged.

Assisted-by: Claude Code:claude-opus-5